### PR TITLE
cssnext includes autoprefixer and have a `browsers` option too

### DIFF
--- a/dev/wikipedia.org/assets/postcss/README.txt
+++ b/dev/wikipedia.org/assets/postcss/README.txt
@@ -25,9 +25,10 @@ _ie.css - reserved for IE6 and IE7 specific styles.
 PostCSS Plugins Used:
 =====================
 
-CSSNext
+cssnext
   http://cssnext.io/
-  offers css custom properties and a range of future css standard features.
+  offers css custom properties and a range of future css standard features
+  as well as vendor prefixes (-webkit-, -moz-, -ms, -o-) where necessary.
 
 PostCSS-Import
   https://github.com/postcss/postcss-import
@@ -37,7 +38,3 @@ PostCSS-Import
 PostCSS-CSSSimple
   https://www.npmjs.com/package/postcss-csssimple
   Fixes IE6-8 bugs, like adding _zoom:1 to display:inline-block.
-
-Autoprefixer
-  https://github.com/postcss/autoprefixer
-  Adds vendor prefixes (-webkit-, -moz-, -ms, -o-) where necessary.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,6 @@ var gulp = require( 'gulp' ),
 	sprity = require( 'sprity' ),
 	postCSSNext = require( 'postcss-cssnext' ),
 	postCSSImport = require( 'postcss-import' ),
-	autoprefixer = require( 'autoprefixer' ),
 	postCSSSimple = require( 'postcss-csssimple' );
 
 var plugins = gulpLoadPlugins(),
@@ -174,8 +173,7 @@ gulp.task( 'postcss', function () {
 	return gulp.src( [ getBaseDir() + 'assets/postcss/*.css', '!' + getBaseDir() + 'assets/postcss/_*.css' ] )
 		.pipe( plugins.postcss( [
 			postCSSImport(),
-			postCSSNext(),
-			autoprefixer( { browsers: [ 'last 5 versions', 'ie 6-8', 'Firefox >= 3.5', 'iOS >= 4', 'Android >= 2.3' ] } ),
+			postCSSNext({ browsers: [ 'last 5 versions', 'ie 6-8', 'Firefox >= 3.5', 'iOS >= 4', 'Android >= 2.3' ] }),
 			postCSSSimple()
 		],
 			{ map: { inline: true } }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "el-abtest3": "casperjs test ./tests/el-abtest3.js"
   },
   "devDependencies": {
-    "autoprefixer": "^6.3.1",
     "bluebird": "^3.0.5",
     "cssnext": "^1.8.4",
     "del": "^2.2.0",


### PR DESCRIPTION
Most tutorial miss this thing. Autoprefixer is included in cssnext (not [CSSNext](http://cssnext.io/it-s-cssnext-not-CSSNext/)) since day 1.
`browsers` option will also allow cssnext to disable transformation in the future ;)